### PR TITLE
Fix for col_start:col_end substitution in initialization code

### DIFF
--- a/cam_driver/src/CMakeLists.txt
+++ b/cam_driver/src/CMakeLists.txt
@@ -114,7 +114,6 @@ else(OPENMP)
 endif()
 
 add_library(library ${library_files})
-INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/library)
 
 # Run ccpp_capgen
 set(CAPGEN_CMD "${CCPP_FRAMEWORK}/scripts/ccpp_capgen.py")

--- a/cam_driver/src/physics_types_cam7.F90
+++ b/cam_driver/src/physics_types_cam7.F90
@@ -40,56 +40,56 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = radians
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ lon ]
 !!   standard_name = longitude
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = radians
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ ps ]
 !!   standard_name = surface_air_pressure
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ psdry ]
 !!   standard_name = dry_surface_pressure
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ phis ]
 !!   standard_name = surface_geopotential
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = m2 s-2
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ ulat ]
 !!   standard_name = unique_latitudes
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = radians
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ ulon ]
 !!   standard_name = unique_longitudes
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = radians
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ t ]
 !!   standard_name = temperature
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = K
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ u ]
 !!   standard_name = eastward_wind
 !!   long_name = Zonal wind
@@ -97,7 +97,7 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = m s-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ v ]
 !!   standard_name = northward_wind
 !!   long_name = Meridional wind
@@ -105,7 +105,7 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = m s-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ s ]
 !!   standard_name = dry_static_energy_content_of_atmosphere_layer
 !!   long_name = Dry static energy
@@ -113,7 +113,7 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = J m-2
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ omega ]
 !!   standard_name = lagrangian_tendency_of_air_pressure
 !!   long_name = Vertical pressure velocity
@@ -121,7 +121,7 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa s-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ pmid ]
 !!   standard_name = air_pressure
 !!   long_name = Midpoint air pressure
@@ -129,7 +129,7 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ pmiddry ]
 !!   standard_name = air_pressure_of_dry_air
 !!   long_name = Dry midpoint pressure
@@ -137,49 +137,49 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ pdel ]
 !!   standard_name = pressure_thickness
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ pdeldry ]
 !!   standard_name = pressure_thickness_of_dry_air
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ rpdel ]
 !!   standard_name = reciprocal_of_pressure_thickness
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ rpdeldry ]
 !!   standard_name = reciprocal_of_pressure_thickness_of_dry_air
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ lnpmid ]
 !!   standard_name = natural_log_of_air_pressure
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = pmid
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ lnpmiddry ]
 !!   standard_name = log_of_air_pressure_of_dry_air
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ exner ]
 !!   standard_name = inverse_exner_function_wrt_surface_pressure
 !!   long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
@@ -187,119 +187,119 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = 1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ zm ]
 !!   standard_name = geopotential_height_above_surface_at_midpoints
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = m
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ q ]
 !!   standard_name = constituent_mixing_ratio
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = kg/kg moist or dry air depending on type
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension, number_of_tracers)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension, number_of_tracers)
 !! [ q(:,:,index_of_water_vapor_specific_humidity) ]
 !!   standard_name = water_vapor_specific_humidity
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = kg kg-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ q(:,:,index_of_cloud_liquid_water_mixing_ratio) ]
 !!   standard_name = cloud_liquid_water_mixing_ratio
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = kg kg-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ q(:,:,index_of_rain_water_mixing_ratio) ]
 !!   standard_name = rain_water_mixing_ratio
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = kg kg-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ pint ]
 !!   standard_name = air_pressure_at_interface
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_level_dimension)
+!!   dimensions = (horizontal_dimension, vertical_level_dimension)
 !! [ pintdry ]
 !!   standard_name = interface_pressure_dry
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa
-!!   dimensions = (horizontal_loop_extent, vertical_level_dimension)
+!!   dimensions = (horizontal_dimension, vertical_level_dimension)
 !! [ lnpint ]
 !!   standard_name = ln_air_pressure_at_interface
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = ln(Pa)
-!!   dimensions = (horizontal_loop_extent, vertical_level_dimension)
+!!   dimensions = (horizontal_dimension, vertical_level_dimension)
 !! [ lnpintdry ]
 !!   standard_name = ln_interface_pressure_dry
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = ln(Pa)
-!!   dimensions = (horizontal_loop_extent, vertical_level_dimension)
+!!   dimensions = (horizontal_dimension, vertical_level_dimension)
 !! [ zi ]
 !!   standard_name = geopotential_height_above_surface_at_interfaces
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = m
-!!   dimensions = (horizontal_loop_extent, vertical_level_dimension)
+!!   dimensions = (horizontal_dimension, vertical_level_dimension)
 !! [ te_ini ]
 !!   standard_name = vertically_integrated_total_kinetic_and_static_energy_of_initial_state
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = J m-2
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ te_cur ]
 !!   standard_name = vertically_integrated_total_kinetic_and_static_energy_of_current_state
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = J m-2
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ tw_ini ]
 !!   standard_name = vertically_integrated_total_water_of_initial_state
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa s2 m-1
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ tw_cur ]
 !!   standard_name = vertically_integrated_total_water_of_new_state
 !!   state_variable = true
 !!   type = real
 !!   kind = kind_phys
 !!   units = Pa s2 m-1
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ count ]
 !!   standard_name = count_of_values_with_significant_energy_or_water_imbalances
 !!   state_variable = true
 !!   type = integer
 !!   kind = kind_phys
 !!   units = 1
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ cid ]
 !!   standard_name = unique_column_id
 !!   state_variable = true
 !!   type = integer
 !!   kind = kind_phys
 !!   units = 1
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !!
    type physics_state
       integer                                     :: &
@@ -362,42 +362,42 @@ module physics_types
 !!   type = real
 !!   kind = kind_phys
 !!   units = K s-1
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ dudt ]
 !!   standard_name = total_tendency_of_eastward_wind
 !!   state_variable = false
 !!   type = real
 !!   kind = kind_phys
 !!   units = m s-2
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ dvdt ]
 !!   standard_name = total_tendency_of_northward_wind
 !!   state_variable = false
 !!   type = real
 !!   kind = kind_phys
 !!   units = m s-2
-!!   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+!!   dimensions = (horizontal_dimension, vertical_layer_dimension)
 !! [ flx_net ]
 !!   standard_name = surface_energy_flux
 !!   state_variable = false
 !!   type = real
 !!   kind = kind_phys
 !!   units = W m-2
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ te_tnd ]
 !!   standard_name = cumulative_boundary_flux_of_total_energy
 !!   state_variable = false
 !!   type = real
 !!   kind = kind_phys
 !!   units = W m-2
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !! [ tw_tnd ]
 !!   standard_name = cumulative_boundary_flux_of_total_water
 !!   state_variable = false
 !!   type = real
 !!   kind = kind_phys
 !!   units = W m-2
-!!   dimensions = (horizontal_loop_extent)
+!!   dimensions = (horizontal_dimension)
 !!
    type physics_tend
 

--- a/simple/CMakeLists.txt
+++ b/simple/CMakeLists.txt
@@ -93,7 +93,6 @@ else(${CMAKE_VERSION} LESS 3.3)
 endif (${CMAKE_VERSION} LESS 3.3)
 
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/simple)
-INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/library)
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Modified physics_types_cam7.F90 to use `horizontal_dimension` instead of `horizontal_loop_extent`.
Updated ccpp-framework tag to fix issue where `intent` was not considered a required argument for schemes (short version -- the parser thought it was parsing a DDT where `intent` is not required).
Fixes gold2718/ccpp-framework#2